### PR TITLE
Reasons for Warnings, Reasons & Removals

### DIFF
--- a/secretlounge_ng/core.py
+++ b/secretlounge_ng/core.py
@@ -396,7 +396,7 @@ def send_admin_message(user: User, arg: str):
 
 @requireUser
 @requireRank(RANKS.mod)
-def warn_user(user: User, msid, delete=False):
+def warn_user(user: User, msid, delete=False, reason: str = ""):
 	cm = ch.getMessage(msid)
 	if cm is None or cm.user_id is None:
 		return rp.Reply(rp.types.ERR_NOT_IN_CACHE)
@@ -406,7 +406,7 @@ def warn_user(user: User, msid, delete=False):
 			d = user2.addWarning()
 			user2.karma -= KARMA_WARN_PENALTY
 		_push_system_message(
-			rp.Reply(rp.types.GIVEN_COOLDOWN, duration=d, deleted=delete),
+			rp.Reply(rp.types.GIVEN_COOLDOWN, duration=d, deleted=delete, reason=reason),
 			who=user2, reply_to=msid)
 		cm.warned = True
 	else:
@@ -420,7 +420,7 @@ def warn_user(user: User, msid, delete=False):
 
 @requireUser
 @requireRank(RANKS.mod)
-def delete_message(user: User, msid):
+def delete_message(user: User, msid, reason: str = ""):
 	if not allow_remove_command:
 		return rp.Reply(rp.types.ERR_COMMAND_DISABLED)
 
@@ -429,7 +429,7 @@ def delete_message(user: User, msid):
 		return rp.Reply(rp.types.ERR_NOT_IN_CACHE)
 
 	user2 = db.getUser(id=cm.user_id)
-	_push_system_message(rp.Reply(rp.types.MESSAGE_DELETED), who=user2, reply_to=msid)
+	_push_system_message(rp.Reply(rp.types.MESSAGE_DELETED, reason=reason), who=user2, reply_to=msid)
 	Sender.delete([msid])
 	logging.info("%s deleted a message from [%s]", user, user2.getObfuscatedId())
 	return rp.Reply(rp.types.SUCCESS)

--- a/secretlounge_ng/core.py
+++ b/secretlounge_ng/core.py
@@ -415,7 +415,7 @@ def warn_user(user: User, msid, delete=False, reason: str = ""):
 			return rp.Reply(rp.types.ERR_ALREADY_WARNED)
 	if delete:
 		Sender.delete([msid])
-	logging.info("%s warned [%s]%s", user, user2.getObfuscatedId(), delete and " (message deleted)" or "")
+	logging.info("%s warned [%s]%s reason: %s", user, user2.getObfuscatedId(), delete and " (message deleted)" or "", reason)
 	return rp.Reply(rp.types.SUCCESS)
 
 @requireUser
@@ -431,7 +431,7 @@ def delete_message(user: User, msid, reason: str = ""):
 	user2 = db.getUser(id=cm.user_id)
 	_push_system_message(rp.Reply(rp.types.MESSAGE_DELETED, reason=reason), who=user2, reply_to=msid)
 	Sender.delete([msid])
-	logging.info("%s deleted a message from [%s]", user, user2.getObfuscatedId())
+	logging.info("%s deleted a message from [%s] reason: %s", user, user2.getObfuscatedId(), reason)
 	return rp.Reply(rp.types.SUCCESS)
 
 @requireUser

--- a/secretlounge_ng/replies.py
+++ b/secretlounge_ng/replies.py
@@ -98,7 +98,7 @@ format_strs = {
 	types.USER_NOT_IN_CHAT: em("You're not in the chat yet. Use /start to join!"),
 	types.GIVEN_COOLDOWN: lambda deleted, reason, **_:
 		em( "You've been handed a cooldown of {duration!d} for this message"+
-			(deleted and " (message also deleted)" or "")+
+			(deleted and " (message also deleted)." or ".")+
 			(reason and " Reason: {reason!x}") or ""),
 	types.MESSAGE_DELETED: lambda reason, **_:
 		em( "Your message has been deleted. No cooldown has been "

--- a/secretlounge_ng/replies.py
+++ b/secretlounge_ng/replies.py
@@ -96,12 +96,14 @@ format_strs = {
 	types.CHAT_LEAVE: em("You left the chat!"),
 	types.USER_IN_CHAT: em("You're already in the chat."),
 	types.USER_NOT_IN_CHAT: em("You're not in the chat yet. Use /start to join!"),
-	types.GIVEN_COOLDOWN: lambda deleted, **_:
+	types.GIVEN_COOLDOWN: lambda deleted, reason, **_:
 		em( "You've been handed a cooldown of {duration!d} for this message"+
-			(deleted and " (message also deleted)" or "") ),
-	types.MESSAGE_DELETED:
+			(deleted and " (message also deleted)" or "")+
+			(reason and " Reason: {reason!x}") or ""),
+	types.MESSAGE_DELETED: lambda reason, **_:
 		em( "Your message has been deleted. No cooldown has been "
-			"given this time, but refrain from posting it again." ),
+			"given this time, but refrain from posting it again."+
+			(reason and " Reason: {reason!x}") or ""),
 	types.DELETION_QUEUED: em("{count} messages matched, deletion was queued."),
 	types.PROMOTED_MOD: em("You've been promoted to moderator, run /modhelp for a list of commands."),
 	types.PROMOTED_ADMIN: em("You've been promoted to admin, run /adminhelp for a list of commands."),

--- a/secretlounge_ng/telegram.py
+++ b/secretlounge_ng/telegram.py
@@ -652,7 +652,8 @@ def cmd_admin(ev, arg):
 	arg = arg.lstrip("@")
 	send_answer(ev, core.promote_user(c_user, arg, RANKS.admin), True)
 
-def cmd_warn(ev: TMessage, delete=False, only_delete=False):
+@takesArgument(optional=True)
+def cmd_warn(ev: TMessage, arg):
 	c_user = UserContainer(ev.from_user)
 
 	if ev.reply_to_message is None:
@@ -661,15 +662,33 @@ def cmd_warn(ev: TMessage, delete=False, only_delete=False):
 	reply_msid = ch.findMapping(ev.from_user.id, ev.reply_to_message.message_id)
 	if reply_msid is None:
 		return send_answer(ev, rp.Reply(rp.types.ERR_NOT_IN_CACHE), True)
-	if only_delete:
-		r = core.delete_message(c_user, reply_msid)
-	else:
-		r = core.warn_user(c_user, reply_msid, delete)
+	r = core.warn_user(c_user, reply_msid, delete=False, reason=arg)
 	send_answer(ev, r, True)
 
-cmd_delete = partial(cmd_warn, delete=True)
+@takesArgument(optional=True)
+def cmd_delete(ev: TMessage, arg):
+	c_user = UserContainer(ev.from_user)
 
-cmd_remove = partial(cmd_warn, only_delete=True)
+	if ev.reply_to_message is None:
+		return send_answer(ev, rp.Reply(rp.types.ERR_NO_REPLY), True)
+
+	reply_msid = ch.findMapping(ev.from_user.id, ev.reply_to_message.message_id)
+	if reply_msid is None:
+		return send_answer(ev, rp.Reply(rp.types.ERR_NOT_IN_CACHE), True)
+	r = core.warn_user(c_user, reply_msid, delete=True, reason=arg)
+
+@takesArgument(optional=True)
+def cmd_remove(ev: TMessage, arg):
+	c_user = UserContainer(ev.from_user)
+
+	if ev.reply_to_message is None:
+		return send_answer(ev, rp.Reply(rp.types.ERR_NO_REPLY), True)
+
+	reply_msid = ch.findMapping(ev.from_user.id, ev.reply_to_message.message_id)
+	if reply_msid is None:
+		return send_answer(ev, rp.Reply(rp.types.ERR_NOT_IN_CACHE), True)
+	r = core.delete_message(c_user, reply_msid, reason=arg)
+	send_answer(ev, r, True)
 
 cmd_cleanup = wrap_core(core.cleanup_messages)
 


### PR DESCRIPTION
This allows staff to include an **optional** reason for any of the listed actions, which will be logged and shown to the user.

A mod can remove a message with `/remove` just as before, but now they can also append a reason like `/remove Drama is not allowed`, which to the user will appear as:

>Your message has been deleted. No cooldown has been given this time, but refrain from posting it again. Reason: Drama is not allowed

And it will be logged as:

```
INFO    [YYYY-MM-DD HH:MM:SS] <User id=XXXXXXXXXX aka '@Username'> deleted a message from [YYYY] reason: Drama is not allowed
```

`/warn`, `/delete` and `/remove` are supported.