### PR TITLE
Add message downvotes

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -16,6 +16,9 @@ printers_path: "./printers.yaml"
 # location for the karma.yaml file
 karma_path: "./karma.yaml"
 
+# enable downvoting messages
+allow_downvotes: false
+
 # relay contacts
 allow_contacts: false
 # relay arbitrary documents/files (GIFs always work)

--- a/secretlounge_ng/core.py
+++ b/secretlounge_ng/core.py
@@ -553,6 +553,24 @@ def give_karma(user: User, msid):
 	return rp.Reply(rp.types.KARMA_THANK_YOU)
 
 @requireUser
+def take_karma(user: User, msid):
+	cm = ch.getMessage(msid)
+	if cm is None or cm.user_id is None:
+		return rp.Reply(rp.types.ERR_NOT_IN_CACHE)
+
+	if cm.hasUpvoted(user):
+		return rp.Reply(rp.types.ERR_ALREADY_UPVOTED)
+	elif user.id == cm.user_id:
+		return rp.Reply(rp.types.ERR_UPVOTE_OWN_MESSAGE)
+	cm.addUpvote(user)
+	user2 = db.getUser(id=cm.user_id)
+	with db.modifyUser(id=cm.user_id) as user2:
+		user2.karma -= KARMA_PLUS_ONE
+	if not user2.hideKarma:
+		_push_system_message(rp.Reply(rp.types.KARMA_MINUS_NOTIFICATION), who=user2, reply_to=msid)
+	return rp.Reply(rp.types.KARMA_FUCK_YOU)
+
+@requireUser
 def give_custom_karma(user: User, msid, karma_cmd):
 	cm = ch.getMessage(msid)
 	if cm is None or cm.user_id is None:

--- a/secretlounge_ng/replies.py
+++ b/secretlounge_ng/replies.py
@@ -42,6 +42,8 @@ types = NumericEnum([
 	"KARMA_CUSTOM",
 	"KARMA_THANK_YOU",
 	"KARMA_NOTIFICATION",
+	"KARMA_FUCK_YOU",
+	"KARMA_MINUS_NOTIFICATION",
 	"TRIPCODE_INFO",
 	"TRIPCODE_SET",
 
@@ -127,6 +129,10 @@ format_strs = {
 	types.KARMA_NOTIFICATION:
 		em( "You've just been given sweet karma! (check /info to see your karma"+
 			" or /toggleKarma to turn these notifications off)" ),
+	types.KARMA_FUCK_YOU: em("You just took some sweet karma from this user, fuck 'em!"),
+	types.KARMA_MINUS_NOTIFICATION:
+		em( "Someone just took some of your sweet karma! (check /info to see your karma"+
+			" or /toggleKarma to turn these notifications off)" ),
 	types.TRIPCODE_INFO: lambda tripcode, **_:
 		"<b>tripcode</b>: " + ("<code>{tripcode!x}</code>" if tripcode is not None else "unset"),
 	types.TRIPCODE_SET: em("Tripcode set. It will appear as: ") + "<b>{tripname!x}</b> <code>{tripcode!x}</code>",
@@ -142,8 +148,8 @@ format_strs = {
 	types.ERR_BLACKLISTED: lambda reason, contact, **_:
 		em( "You've been blacklisted" + (reason and " for {reason!x}" or "") )+
 		( em("\ncontact:") + " {contact}" if contact else "" ),
-	types.ERR_ALREADY_UPVOTED: em("You have already upvoted this message."),
-	types.ERR_UPVOTE_OWN_MESSAGE: em("You can't upvote your own message."),
+	types.ERR_ALREADY_UPVOTED: em("You have already upvoted/downvoted this message."),
+	types.ERR_UPVOTE_OWN_MESSAGE: em("You can't upvote/downvote your own message."),
 	types.ERR_SPAMMY: em("Your message has not been sent. Avoid sending messages too fast, try again later."),
 	types.ERR_SPAMMY_SIGN: em("Your message has not been sent. Avoid using /sign too often, try again later."),
 	types.ERR_SIGN_PRIVACY: em("Your account privacy settings prevent usage of the sign feature. Enable linked forwards first."),

--- a/secretlounge_ng/telegram.py
+++ b/secretlounge_ng/telegram.py
@@ -47,7 +47,7 @@ karma_cmds = None
 linked_network: dict = None
 
 def init(config: dict, _db, _ch):
-	global bot, db, ch, message_queue, linked_network, enable_tripcode_toggle, printer_cmds, karma_cmds
+	global bot, db, ch, message_queue, linked_network, enable_tripcode_toggle, printer_cmds, karma_cmds, allow_downvotes
 	if not config.get("bot_token") or ":" not in config["bot_token"]:
 		logging.error("No Telegram bot token specified")
 		exit(1)
@@ -62,6 +62,9 @@ def init(config: dict, _db, _ch):
 
 	allow_contacts = config["allow_contacts"]
 	allow_documents = config["allow_documents"]
+
+	allow_downvotes = config.get("allow_downvotes", False)
+
 	linked_network = config.get("linked_network")
 	if linked_network is not None and not isinstance(linked_network, dict):
 		logging.error("Wrong type for 'linked_network'")
@@ -740,6 +743,17 @@ def plusone(ev: TMessage):
 		return send_answer(ev, rp.Reply(rp.types.ERR_NOT_IN_CACHE), True)
 	return send_answer(ev, core.give_karma(c_user, reply_msid), True)
 
+# literal copy of `plusone` but substracts one instead
+def minusone(ev: TMessage):
+	c_user = UserContainer(ev.from_user)
+	if ev.reply_to_message is None:
+		return send_answer(ev, rp.Reply(rp.types.ERR_NO_REPLY), True)
+
+	reply_msid = ch.findMapping(ev.from_user.id, ev.reply_to_message.message_id)
+	if reply_msid is None:
+		return send_answer(ev, rp.Reply(rp.types.ERR_NOT_IN_CACHE), True)
+	return send_answer(ev, core.take_karma(c_user, reply_msid), True)
+
 # literal copy of `plusone` but takes the karma addition as an argument
 def plus_any(ev: TMessage, karma_cmd):
 	c_user = UserContainer(ev.from_user)
@@ -768,6 +782,8 @@ def relay(ev: TMessage):
 			return
 		elif ev.text.strip() == "+1":
 			return plusone(ev)
+		elif allow_downvotes is True and ev.text.strip() == "-1":
+			return minusone(ev)
 	# manually handle signing / tripcodes for media since captions don't count for commands
 	if not is_forward(ev) and ev.content_type in CAPTIONABLE_TYPES and (ev.caption or "").startswith("/"):
 		c, arg = split_command(ev.caption)


### PR DESCRIPTION
Disabled by default, will not throw exceptions if the relevant parameters are not found in the `config.yaml`.

Admittedly I barely tested it since it's a pretty straight forward change.

Closes: #11 